### PR TITLE
Use variable DAO parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# Example
+
+```python
+import boa
+import curve_dao
+
+contract = boa.load("contracts/contract.vy",
+    curve_dao.get_address("ownership"), curve_dao.get_address("param"), curve_dao.get_address("emergency"),  # Set admins
+)
+ACTIONS = [
+    ("0xcontract", "set_something", ("values",), 70, "set"),  # 0xcontract.set_something(("values",), 70, "set)
+    (contract, "enact"),  # contract.enact()
+]
+DESCRIPTION = "Enact something"
+vote_id = curve_dao.create_vote("ownership", ACTIONS, DESCRIPTION,
+                                etherscan_api_key=os.environ["ETHERSCAN_API_KEY"], pinata_token=os.environ["PINATA_TOKEN"])
+if is_simulation:  # forked environment
+    curve_dao.simulate(vote_id, "ownership", etherscan_api_key=os.environ["ETHERSCAN_API_KEY"])
+```
+
 # What is this?
 
 Simple python package to simulate on-chain CurveDAO proposals and publish proposals for DAO voting on-chain.

--- a/curve_dao/__init__.py
+++ b/curve_dao/__init__.py
@@ -1,10 +1,11 @@
 import logging
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 import boa
 from hexbytes import HexBytes
 from rich.logging import RichHandler
 
+from .addresses import DAO, get_address, get_dao_parameters  # noqa: F401
 from .ipfs import pin_to_ipfs  # noqa: F401
 from .simulate import simulate  # noqa: F401
 from .vote_utils import prepare_evm_script  # noqa: F401
@@ -20,17 +21,19 @@ logger = logging.getLogger("rich")
 
 
 def create_vote(
-    target: Dict,
+    dao: str | DAO,
     actions: List[Tuple],
     description: str,
     etherscan_api_key: str,
     pinata_token: str,
 ) -> int:
-    evm_script = prepare_evm_script(target, actions, etherscan_api_key)
+    evm_script = prepare_evm_script(dao, actions, etherscan_api_key)
     ipfs_hash_of_description = pin_to_ipfs(description, pinata_token)
 
     voting = boa.from_etherscan(
-        target["voting"], name="AragonVoting", api_key=etherscan_api_key
+        get_dao_parameters(dao)["voting"],
+        name="AragonVoting",
+        api_key=etherscan_api_key,
     )
 
     try:

--- a/curve_dao/addresses.py
+++ b/curve_dao/addresses.py
@@ -1,3 +1,12 @@
+from enum import StrEnum
+
+
+class DAO(StrEnum):
+    OWNERSHIP = "ownership"
+    PARAM = "param"
+    EMERGENCY = "emergency"
+
+
 CURVE_DAO_OWNERSHIP = {
     "agent": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
     "voting": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
@@ -12,7 +21,9 @@ CURVE_DAO_PARAM = {
     "quorum": 15,
 }
 
-EMERGENCY_DAO = "0x467947EE34aF926cF1DCac093870f613C96B1E0c"
+EMERGENCY_DAO = {
+    "agent": "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+}
 GAUGE_CONTROLLER = "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB"
 VOTING_ESCROW = "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2"
 veCRV = VOTING_ESCROW
@@ -21,16 +32,22 @@ CONVEX_VOTERPROXY = "0x989AEB4D175E16225E39E87D0D97A3360524AD80"
 ADDRESSPROVIDER = "0x5ffe7FB82894076ECB99A30D6A32e969e6e35E98"  # On all chains
 
 
-def get_dao_voting_contract(vote_type: str):
-    target = get_target(vote_type)
-    return target["voting"]
+def get_address(vote_type: DAO | str):
+    """ Get execution address of DAO (e.g. admin role)"""
+    return get_dao_parameters(vote_type)["agent"]
 
 
-def get_target(vote_type: str):
-    match vote_type:
-        case "ownership":
+def get_dao_parameters(vote_type: DAO | str):
+    """
+    :param vote_type: Name, agent address or enum
+    """
+    if vote_type.startswith("0x"):
+        # {agent address: enum}
+        vote_type = {get_dao_parameters(dao)["agent"]: dao for dao in DAO}[vote_type]
+    match DAO(vote_type):
+        case DAO.OWNERSHIP:
             return CURVE_DAO_OWNERSHIP
-        case "parameter":
+        case DAO.PARAM:
             return CURVE_DAO_PARAM
-        case "emergency":
+        case DAO.EMERGENCY:
             return EMERGENCY_DAO

--- a/curve_dao/simulate.py
+++ b/curve_dao/simulate.py
@@ -5,7 +5,7 @@ from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.pretty import Pretty
 
-from .addresses import CONVEX_VOTERPROXY
+from .addresses import CONVEX_VOTERPROXY, DAO, get_dao_parameters
 
 logging.basicConfig(
     level="INFO",
@@ -17,11 +17,11 @@ logging.basicConfig(
 logger = logging.getLogger("rich")
 
 
-def simulate(vote_id: int, voting_contract: str, etherscan_api_key: str):
+def simulate(vote_id: int, dao: str | DAO, etherscan_api_key: str):
     logger.info("Simulating Vote")
 
     voting_contract = boa.from_etherscan(
-        voting_contract, "AragonVoting", api_key=etherscan_api_key
+        get_dao_parameters(dao)["voting"], "AragonVoting", api_key=etherscan_api_key
     )
 
     # print vote details to console first:

--- a/curve_dao/vote_utils.py
+++ b/curve_dao/vote_utils.py
@@ -1,10 +1,12 @@
 import logging
 import warnings
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 import boa
 from hexbytes import HexBytes
 from rich.logging import RichHandler
+
+from curve_dao.addresses import DAO, get_dao_parameters
 
 warnings.filterwarnings("ignore")
 
@@ -22,7 +24,7 @@ class MissingVote(Exception):
     """Exception raised when a vote ID is invalid."""
 
 
-def prepare_evm_script(target: Dict, actions: List[Tuple], etherscan_api_key: str):
+def prepare_evm_script(dao: str | DAO, actions: List[Tuple], etherscan_api_key: str):
     """Generates EVM script to be executed by AragonDAO contracts.
 
     Args:
@@ -33,7 +35,7 @@ def prepare_evm_script(target: Dict, actions: List[Tuple], etherscan_api_key: st
         str: Generated EVM script.
     """
     aragon_agent = boa.from_etherscan(
-        target["agent"], name="AragonAgent", api_key=etherscan_api_key
+        get_dao_parameters(dao)["agent"], name="AragonAgent", api_key=etherscan_api_key
     )
 
     logger.info("Preparing EVM script")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "curve-dao"
-version = "0.0.6"
+version = "1.0.0"
 description = "DAO governance tools for CurveDAO."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/tests/test_addresses.py
+++ b/tests/test_addresses.py
@@ -1,0 +1,27 @@
+import pytest
+
+import curve_dao
+
+
+def test_get_address():
+    assert curve_dao.get_address("ownership") == curve_dao.get_address(
+        curve_dao.addresses.DAO.OWNERSHIP
+    )
+    assert curve_dao.get_address("param") == curve_dao.get_address(
+        curve_dao.addresses.DAO.PARAM
+    )
+    assert curve_dao.get_address("emergency") == curve_dao.get_address(
+        curve_dao.addresses.DAO.EMERGENCY
+    )
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        curve_dao.addresses.DAO.OWNERSHIP,
+        "param",
+        "0x467947EE34aF926cF1DCac093870f613C96B1E0c",
+    ],
+)
+def test_target(target, etherscan_api_key):
+    curve_dao.prepare_evm_script(target, [], etherscan_api_key)

--- a/tests/test_kill_gauge.py
+++ b/tests/test_kill_gauge.py
@@ -1,3 +1,5 @@
+import time
+
 import boa
 import pytest
 
@@ -6,6 +8,7 @@ import curve_dao
 
 @pytest.fixture
 def gauge_to_kill(etherscan_api_key):
+    time.sleep(1)  # Etherscan API limit
     return boa.from_etherscan(
         "0x04e80db3f84873e4132b221831af1045d27f140f",
         name="LiquidityGaugeV6",
@@ -25,7 +28,7 @@ def description():
 
 @pytest.fixture
 def target():
-    return curve_dao.addresses.CURVE_DAO_OWNERSHIP
+    return curve_dao.addresses.DAO.OWNERSHIP
 
 
 @pytest.fixture
@@ -36,7 +39,7 @@ def evm_script(target, actions, etherscan_api_key):
 def test_evm_script(evm_script):
     assert (
         evm_script.hex()
-        == "0000000140907540d8a6c65c637785e8f8b742ae6b0b9968000000c4b61d27f600000000000000000000000004e80db3f84873e4132b221831af1045d27f140f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000002490b22997000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000"
+        == "0x0000000140907540d8a6c65c637785e8f8b742ae6b0b9968000000c4b61d27f600000000000000000000000004e80db3f84873e4132b221831af1045d27f140f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000002490b22997000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000"
     )
 
 
@@ -45,6 +48,7 @@ def test_evm_script(evm_script):
 def test_create_vote(
     target, actions, description, etherscan_api_key, pinata_token, vote_creator
 ):
+    time.sleep(1)  # Etherscan API limit
     with boa.env.prank(vote_creator):
         vote_id = curve_dao.create_vote(
             target, actions, description, etherscan_api_key, pinata_token
@@ -56,7 +60,7 @@ def test_create_vote(
 @pytest.fixture
 def test_simulate(test_create_vote, target, etherscan_api_key):
     vote_id = test_create_vote
-    assert curve_dao.simulate(vote_id, target["voting"], etherscan_api_key)
+    assert curve_dao.simulate(vote_id, target, etherscan_api_key)
 
 
 def test_gauge_killed(test_create_vote, test_simulate, gauge_to_kill):


### PR DESCRIPTION
## Why
There is no need for the user to know which contract (voting/agent) is used. Made it so you can simply pass `"ownership"` or the address itself.

Also added a simple way to retrieve address to set as admin.