### PR TITLE
bump python version to  3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: black
         args:
           - --skip-magic-trailing-comma
-          - --target-version=py310
+          - --target-version=py311
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ include = ["curve_dao"]
 
 [tool.black]
 line-length = 88
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION

"strEnum" is not part of the python 3.10 standard library, error from colab, where python version is 3.10.12,

![Screenshot at 2024-08-23 13-42-03](https://github.com/user-attachments/assets/b071afbe-99b5-4cb4-9d9d-a9941bc0b5f3)
