### PR TITLE
add support for changing twocrypto params

### DIFF
--- a/curve_dao/proposals.py
+++ b/curve_dao/proposals.py
@@ -1,7 +1,7 @@
 import datetime
 
 import boa
-
+import math
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S%z"
 
 
@@ -51,6 +51,64 @@ def update_stableswap(
         f"Update StableswapNG parameters for pool {pool_address} with: "
         f"fee from {current_fee_bps} -> {new_fee_bps} bps, "
         f"offpeg multiplier from {current_offpeg_multiplier} -> {new_offpeg_fee_multiplier}, "
+        f"amplification factor from {current_A} -> {new_A} ramped over {ramp_time_weeks} weeks "
+        f"starting on {ramp_start_datestring} and ending on {ramp_end_datestring}."
+    )
+
+    return actions, description
+
+
+def update_twocrypto_ng(
+        pool,
+        ramp_time_weeks,
+        new_A,
+        new_gamma,
+        new_mid_fee,
+        new_out_fee,
+        new_fee_gamma,
+        new_allowed_extra_profit,
+        new_adjustment_step,
+        new_ma_time,
+        proposal_time_weeks,
+):
+    """
+    ma_time input is in seconds. divides by log(2) because of the way the twocrypto pool calculates ma_time
+    """
+    SECONDS_PER_WEEK = 7 * 24 * 60 * 60
+
+    ramp_time_seconds = int(ramp_time_weeks * SECONDS_PER_WEEK)
+    proposal_time_seconds = int(proposal_time_weeks * SECONDS_PER_WEEK)
+
+    current_time = boa.env.evm.patch.timestamp
+    future_A_time = current_time + ramp_time_seconds + proposal_time_seconds
+
+    pool_address = pool.address.strip()
+    actions = [
+        (pool_address, "ramp_A_gamma", new_A, new_gamma, future_A_time),    # adjust A and gamma
+        (pool_address, "apply_new_parameters", new_mid_fee, new_out_fee, new_fee_gamma, new_allowed_extra_profit, new_adjustment_step, int(new_ma_time / math.log(2)))
+    ]
+
+    current_A = pool.A()
+    current_gamma = pool.gamma()
+    current_mid_fee = pool.mid_fee()
+    current_out_fee = pool.out_fee()
+    current_fee_gamma = pool.fee_gamma()
+    current_allowed_extra_profit = pool.allowed_extra_profit()
+    current_adjustment_step = pool.adjustment_step()
+    current_ma_time = pool.ma_time()
+
+    ramp_start_time = future_A_time - ramp_time_seconds
+    ramp_start_datestring = get_datestring(ramp_start_time)
+    ramp_end_datestring = get_datestring(future_A_time)
+
+    description = (
+        f"Update TwocryptoNG parameters for pool {pool_address} with: "
+        f"mid_fee from {current_mid_fee} -> {new_mid_fee}, "
+        f"out_fee from {current_out_fee} -> {new_out_fee}, "
+        f"fee_gamma from {current_fee_gamma} -> {new_fee_gamma}, "
+        f"allowed_extra_profit from {current_allowed_extra_profit} -> {new_allowed_extra_profit}, "
+        f"adjustment_step from {current_adjustment_step} -> {new_adjustment_step}, "
+        f"ma_time from {current_ma_time} -> {new_ma_time}, "
         f"amplification factor from {current_A} -> {new_A} ramped over {ramp_time_weeks} weeks "
         f"starting on {ramp_start_datestring} and ending on {ramp_end_datestring}."
     )

--- a/curve_dao/proposals.py
+++ b/curve_dao/proposals.py
@@ -71,9 +71,6 @@ def update_twocrypto_ng(
         new_ma_time,
         proposal_time_weeks,
 ):
-    """
-    ma_time input is in seconds. divides by log(2) because of the way the twocrypto pool calculates ma_time
-    """
     SECONDS_PER_WEEK = 7 * 24 * 60 * 60
 
     ramp_time_seconds = int(ramp_time_weeks * SECONDS_PER_WEEK)
@@ -110,6 +107,68 @@ def update_twocrypto_ng(
         f"adjustment_step from {current_adjustment_step} -> {new_adjustment_step}, "
         f"ma_time from {current_ma_time} -> {new_ma_time}, "
         f"amplification factor from {current_A} -> {new_A} ramped over {ramp_time_weeks} weeks "
+        f"gamma from {current_gamma} -> {new_gamma} ramped over {ramp_time_weeks} weeks "
+        f"starting on {ramp_start_datestring} and ending on {ramp_end_datestring}."
+    )
+
+    return actions, description
+
+
+def update_twocrypto(
+    pool,
+    ramp_time_weeks,
+    new_A,
+    new_gamma,
+    new_mid_fee,
+    new_out_fee,
+    new_admin_fee,
+    new_fee_gamma,
+    new_allowed_extra_profit,
+    new_adjustment_step,
+    new_ma_half_time,
+    proposal_time_weeks,
+):
+    SECONDS_PER_WEEK = 7 * 24 * 60 * 60
+    CRYPTOSWAP_OWNER_PROXY = "0x5a8fdC979ba9b6179916404414F7BA4D8B77C8A1"
+
+
+    ramp_time_seconds = int(ramp_time_weeks * SECONDS_PER_WEEK)
+    proposal_time_seconds = int(proposal_time_weeks * SECONDS_PER_WEEK)
+
+    current_time = boa.env.evm.patch.timestamp
+    future_A_time = current_time + ramp_time_seconds + proposal_time_seconds
+
+    pool_address = pool.address.strip()
+    actions = [
+        (CRYPTOSWAP_OWNER_PROXY, "ramp_A_gamma", pool, new_A, new_gamma, future_A_time),
+        (CRYPTOSWAP_OWNER_PROXY, "commit_new_parameters", pool, new_mid_fee, new_out_fee, new_admin_fee, new_fee_gamma, new_allowed_extra_profit, new_adjustment_step, new_ma_half_time)
+    ]
+
+    current_A = pool.A()
+    current_gamma = pool.gamma()
+    current_mid_fee = pool.mid_fee()
+    current_out_fee = pool.out_fee()
+    current_admin_fee = pool.admin_fee()
+    current_fee_gamma = pool.fee_gamma()
+    current_allowed_extra_profit = pool.allowed_extra_profit()
+    current_adjustment_step = pool.adjustment_step()
+    current_ma_half_time = pool.ma_half_time()
+
+    ramp_start_time = future_A_time - ramp_time_seconds
+    ramp_start_datestring = get_datestring(ramp_start_time)
+    ramp_end_datestring = get_datestring(future_A_time)
+
+    description = (
+        f"Update Twocrypto parameters for pool {pool_address} with: "
+        f"mid_fee from {current_mid_fee} -> {new_mid_fee}, "
+        f"out_fee from {current_out_fee} -> {new_out_fee}, "
+        f"admin_fee from {current_admin_fee} -> {new_admin_fee}, "
+        f"fee_gamma from {current_fee_gamma} -> {new_fee_gamma}, "
+        f"allowed_extra_profit from {current_allowed_extra_profit} -> {new_allowed_extra_profit}, "
+        f"adjustment_step from {current_adjustment_step} -> {new_adjustment_step}, "
+        f"ma_half_time from {current_ma_half_time} -> {new_ma_half_time}, "
+        f"amplification factor from {current_A} -> {new_A} and "
+        f"gamma from {current_gamma} -> {new_gamma} ramped over {ramp_time_weeks} weeks "
         f"starting on {ramp_start_datestring} and ending on {ramp_end_datestring}."
     )
 

--- a/examples/update_twocrypto.py
+++ b/examples/update_twocrypto.py
@@ -1,0 +1,85 @@
+import os
+
+import boa
+from rich import print
+import math
+from curve_dao import create_vote, get_address, simulate
+from curve_dao.proposals import update_twocrypto
+
+# Load environment variables and fork the Ethereum mainnet
+boa.fork(os.getenv("RPC_ETHEREUM"))
+
+# Set up constants
+VOTE_CREATOR_SIM = "0xE6DA683076b7eD6ce7eC972f21Eb8F91e9137a17"
+POOL_ADDRESS = "0x7fb53345f1b21ab5d9510adb38f7d3590be6364b"
+RAMP_TIME_WEEKS = 1
+
+# new parameters
+NEW_A = 20000001
+NEW_GAMMA = 10000000000000001
+NEW_MID_FEE = 3000001
+NEW_OUT_FEE = 45000001
+NEW_ADMIN_FEE = 5000000001
+NEW_FEE_GAMMA = 300000000000000001
+NEW_ALLOWED_EXTRA_PROFIT = 10000000001
+NEW_ADJUSTMENT_STEP = 5500000000001
+NEW_MA_HALF_TIME = 610
+
+# proposal time
+PROPOSAL_TIME_WEEKS = 1
+
+# Load the TwocrptoNG contract
+pool = boa.from_etherscan(
+    POOL_ADDRESS, name="TwocrptoNG", api_key=os.getenv("ETHERSCAN_API_KEY")
+)
+
+# Generate proposal actions and description
+actions, description = update_twocrypto(
+    pool,
+    RAMP_TIME_WEEKS,
+    NEW_A,
+    NEW_GAMMA,
+    NEW_MID_FEE,
+    NEW_OUT_FEE,
+    NEW_ADMIN_FEE,
+    NEW_FEE_GAMMA,
+    NEW_ALLOWED_EXTRA_PROFIT,
+    NEW_ADJUSTMENT_STEP,
+    NEW_MA_HALF_TIME,
+    PROPOSAL_TIME_WEEKS,
+)
+
+# Create and submit the proposal
+with boa.env.prank(VOTE_CREATOR_SIM):
+    vote_id = create_vote(
+        get_address("param"),
+        actions,
+        description,
+        os.getenv("ETHERSCAN_API_KEY"),
+        os.getenv("PINATA_TOKEN"),
+    )
+print(f"Vote ID: {vote_id}")
+
+# Simulate the proposal execution
+simulate(vote_id, get_address("param"), os.getenv("ETHERSCAN_API_KEY"))
+
+# Time travel to after the ramp period
+boa.env.time_travel(seconds=60 * 60 * 24 * 8)  # 8 days (7 days ramp + 1 day buffer)
+
+# Verify the new parameters
+
+A_gamma = pool.future_A_gamma()
+A = A_gamma >> 128
+gamma = A_gamma & ((1 << 128) - 1)    
+
+assert A == NEW_A
+assert gamma == NEW_GAMMA
+assert pool.future_mid_fee() == NEW_MID_FEE
+assert pool.future_out_fee() == NEW_OUT_FEE
+assert pool.future_admin_fee() == NEW_ADMIN_FEE
+assert pool.future_fee_gamma() == NEW_FEE_GAMMA
+assert pool.future_allowed_extra_profit() == NEW_ALLOWED_EXTRA_PROFIT
+assert pool.future_adjustment_step() == NEW_ADJUSTMENT_STEP
+assert pool.future_ma_half_time() == NEW_MA_HALF_TIME
+
+print("All parameters updated successfully!")

--- a/examples/update_twocryptoNG.py
+++ b/examples/update_twocryptoNG.py
@@ -1,0 +1,91 @@
+import os
+
+import boa
+from rich import print
+import math
+from curve_dao import create_vote, get_address, simulate
+from curve_dao.proposals import update_twocrypto_ng
+
+# Load environment variables and fork the Ethereum mainnet
+boa.env.fork(os.getenv("RPC_ETHEREUM"))
+
+# Set up constants
+VOTE_CREATOR_SIM = "0xE6DA683076b7eD6ce7eC972f21Eb8F91e9137a17"
+POOL_ADDRESS = "0x8c65cec3847ad99bdc02621bdbc89f2ace56934b"
+RAMP_TIME_WEEKS = 1
+
+# new parameters
+NEW_A = 20000001
+NEW_GAMMA = 20000000000000001
+NEW_MID_FEE = 700001
+NEW_OUT_FEE = 8000001
+NEW_FEE_GAMMA = 300000000000000001
+NEW_ALLOWED_EXTRA_PROFIT = 10000000001
+NEW_ADJUSTMENT_STEP = 5500000000001
+NEW_MA_TIME = 610
+
+# proposal time
+PROPOSAL_TIME_WEEKS = 1
+
+# Load the TwocrptoNG contract
+pool = boa.from_etherscan(
+    POOL_ADDRESS, name="TwocrptoNG", api_key=os.getenv("ETHERSCAN_API_KEY")
+)
+
+# Generate proposal actions and description
+actions, description = update_twocrypto_ng(
+    pool,
+    RAMP_TIME_WEEKS,
+    NEW_A,
+    NEW_GAMMA,
+    NEW_MID_FEE,
+    NEW_OUT_FEE,
+    NEW_FEE_GAMMA,
+    NEW_ALLOWED_EXTRA_PROFIT,
+    NEW_ADJUSTMENT_STEP,
+    NEW_MA_TIME,
+    PROPOSAL_TIME_WEEKS,
+)
+
+# Create and submit the proposal
+with boa.env.prank(VOTE_CREATOR_SIM):
+    vote_id = create_vote(
+        get_address("ownership"),
+        actions,
+        description,
+        os.getenv("ETHERSCAN_API_KEY"),
+        os.getenv("PINATA_TOKEN"),
+    )
+print(f"Vote ID: {vote_id}")
+
+# Simulate the proposal execution
+simulate(vote_id, get_address("ownership"), os.getenv("ETHERSCAN_API_KEY"))
+
+# Time travel to after the ramp period
+boa.env.time_travel(seconds=60 * 60 * 24 * 8)  # 8 days (7 days ramp + 1 day buffer)
+
+# Verify the new parameters
+
+assert pool.A() == NEW_A
+assert pool.gamma() == NEW_GAMMA
+assert pool.mid_fee() == NEW_MID_FEE
+assert pool.out_fee() == NEW_OUT_FEE
+assert pool.fee_gamma() == NEW_FEE_GAMMA
+assert pool.allowed_extra_profit() == NEW_ALLOWED_EXTRA_PROFIT
+assert pool.adjustment_step() == NEW_ADJUSTMENT_STEP
+print(f"Expected MA time (contract value): {NEW_MA_TIME}")
+print(f"Actual MA time (contract value): {pool.ma_time()}")
+
+# Define an acceptable error margin (e.g., 0.5%)
+ERROR_MARGIN = 5
+
+# Check if the actual value is within the acceptable range
+lower_bound = NEW_MA_TIME * (1 - ERROR_MARGIN)
+upper_bound = NEW_MA_TIME * (1 + ERROR_MARGIN)
+
+assert lower_bound <= pool.ma_time() <= upper_bound, (
+    f"MA time {pool.ma_time()} is outside the acceptable range "
+    f"[{lower_bound}, {upper_bound}]"
+)
+
+print("All parameters updated successfully!")

--- a/examples/update_twocrypto_ng.py
+++ b/examples/update_twocrypto_ng.py
@@ -7,7 +7,7 @@ from curve_dao import create_vote, get_address, simulate
 from curve_dao.proposals import update_twocrypto_ng
 
 # Load environment variables and fork the Ethereum mainnet
-boa.env.fork(os.getenv("RPC_ETHEREUM"))
+boa.fork(os.getenv("RPC_ETHEREUM"))
 
 # Set up constants
 VOTE_CREATOR_SIM = "0xE6DA683076b7eD6ce7eC972f21Eb8F91e9137a17"

--- a/tests/test_update_twocrypto.py
+++ b/tests/test_update_twocrypto.py
@@ -1,0 +1,159 @@
+import boa
+import pytest
+import math
+
+import curve_dao
+
+
+@pytest.fixture
+def target():
+    return curve_dao.addresses.DAO.PARAM
+
+
+@pytest.fixture
+def pool(etherscan_api_key):
+    return boa.from_etherscan(
+        "0x7fb53345f1b21ab5d9510adb38f7d3590be6364b",  # TwoCrypto pool address
+        name="TwoCrypto",
+        api_key=etherscan_api_key,
+    )
+
+
+@pytest.fixture
+def ramp_time_weeks():
+    return 1
+
+
+@pytest.fixture
+def new_A():
+    return 20000001
+
+
+@pytest.fixture
+def new_gamma():
+    return 10000000000000001
+
+
+@pytest.fixture
+def new_mid_fee():
+    return 3000001
+
+
+@pytest.fixture
+def new_out_fee():
+    return 45000001
+
+
+@pytest.fixture
+def new_admin_fee():
+    return 5000000001
+
+
+@pytest.fixture
+def new_fee_gamma():
+    return 300000000000000001
+
+
+@pytest.fixture
+def new_allowed_extra_profit():
+    return 10000000001
+
+
+@pytest.fixture
+def new_adjustment_step():
+    return 5500000000001
+
+
+@pytest.fixture
+def new_ma_half_time():
+    return 610
+
+
+@pytest.fixture
+def proposal_time_weeks():
+    return 1
+
+
+@pytest.fixture
+def actions_and_description(
+    pool,
+    ramp_time_weeks,
+    new_A,
+    new_gamma,
+    new_mid_fee,
+    new_out_fee,
+    new_admin_fee,
+    new_fee_gamma,
+    new_allowed_extra_profit,
+    new_adjustment_step,
+    new_ma_half_time,
+    proposal_time_weeks,
+):
+    actions, description = curve_dao.proposals.update_twocrypto(
+        pool,
+        ramp_time_weeks,
+        new_A,
+        new_gamma,
+        new_mid_fee,
+        new_out_fee,
+        new_admin_fee,
+        new_fee_gamma,
+        new_allowed_extra_profit,
+        new_adjustment_step,
+        new_ma_half_time,
+        proposal_time_weeks,
+    )
+    assert actions == [
+        (
+            "0x5a8fdC979ba9b6179916404414F7BA4D8B77C8A1",  # owner proxy address
+            "ramp_A_gamma",
+            pool,   # Use the pool object directly
+            20000001,
+            10000000000000001,
+            1726688231
+        ),
+        (
+            "0x5a8fdC979ba9b6179916404414F7BA4D8B77C8A1",  # owner proxy address
+            "commit_new_parameters",
+            pool,   # Use the pool object directly
+            3000001,                # new mid_fee
+            45000001,               # new out_fee
+            5000000001,             # new admin_fee
+            300000000000000001,     # new fee_gamma
+            10000000001,
+            5500000000001,
+            610,  # new ma_half_time (without conversion)
+        ),
+    ]
+    return actions, description
+
+
+def test_simulate_success(
+    pool, vote_creator, target, etherscan_api_key, pinata_token, actions_and_description
+):
+    actions, description = actions_and_description
+
+    with boa.env.prank(vote_creator):
+        vote_id = curve_dao.create_vote(
+            target, actions, description, etherscan_api_key, pinata_token
+        )
+
+    assert curve_dao.simulate(vote_id, target, etherscan_api_key)
+
+    boa.env.time_travel(
+        seconds=60 * 60 * 24 * 8
+    )  # sleep 7(+1) days for ramp to complete
+
+    A_gamma = pool.future_A_gamma()
+    A = A_gamma >> 128
+    gamma = A_gamma & ((1 << 128) - 1)
+
+    assert A == 20000001
+    assert gamma == 10000000000000001
+    assert pool.future_mid_fee() == 3000001
+    assert pool.future_out_fee() == 45000001
+    assert pool.future_admin_fee() == 5000000001
+    assert pool.future_fee_gamma() == 300000000000000001
+    assert pool.future_allowed_extra_profit() == 10000000001
+    assert pool.future_adjustment_step() == 5500000000001
+    assert pool.future_ma_half_time() == 610

--- a/tests/test_update_twocrypto_ng.py
+++ b/tests/test_update_twocrypto_ng.py
@@ -1,0 +1,142 @@
+import boa
+import pytest
+import math
+
+import curve_dao
+
+
+@pytest.fixture
+def target():
+    return curve_dao.addresses.DAO.OWNERSHIP
+
+
+@pytest.fixture
+def pool(etherscan_api_key):
+    return boa.from_etherscan(
+        "0x8c65CeC3847ad99BdC02621bDBC89F2acE56934B",
+        name="TwoCryptoNG",
+        api_key=etherscan_api_key,
+    )
+
+
+@pytest.fixture
+def ramp_time_weeks():
+    return 1
+
+
+@pytest.fixture
+def new_A():
+    return 20000001
+
+
+@pytest.fixture
+def new_gamma():
+    return 20000000000000001
+
+
+@pytest.fixture
+def new_mid_fee():
+    return 700001
+
+
+@pytest.fixture
+def new_out_fee():
+    return 8000001
+
+
+@pytest.fixture
+def new_fee_gamma():
+    return 300000000000000001
+
+
+@pytest.fixture
+def new_allowed_extra_profit():
+    return 10000000001
+
+
+@pytest.fixture
+def new_adjustment_step():
+    return 5500000000001
+
+
+@pytest.fixture
+def new_ma_time():
+    return 610
+
+
+@pytest.fixture
+def proposal_time_weeks():
+    return 1
+
+
+@pytest.fixture
+def actions_and_description(
+    pool,
+    ramp_time_weeks,
+    new_A,
+    new_gamma,
+    new_mid_fee,
+    new_out_fee,
+    new_fee_gamma,
+    new_allowed_extra_profit,
+    new_adjustment_step,
+    new_ma_time,
+    proposal_time_weeks,
+):
+    actions, description = curve_dao.proposals.update_twocrypto_ng(
+        pool,
+        ramp_time_weeks,
+        new_A,
+        new_gamma,
+        new_mid_fee,
+        new_out_fee,
+        new_fee_gamma,
+        new_allowed_extra_profit,
+        new_adjustment_step,
+        new_ma_time,
+        proposal_time_weeks,
+    )
+    assert actions == [
+        (
+            "0x8c65CeC3847ad99BdC02621bDBC89F2acE56934B",
+            "ramp_A_gamma",
+            20000001,
+            20000000000000001,
+            1726688231),
+        (
+            "0x8c65CeC3847ad99BdC02621bDBC89F2acE56934B",
+            "apply_new_parameters",
+            700001,                 # new mid_fee
+            8000001,                # new out_fee
+            300000000000000001,     # new fee_gamma
+            10000000001,
+            5500000000001,
+            int(610 / math.log(2)),  # Update this line
+        ),
+    ]
+    return actions, description
+
+
+def test_simulate_success(
+    pool, vote_creator, target, etherscan_api_key, pinata_token, actions_and_description
+):
+    actions, description = actions_and_description
+
+    with boa.env.prank(vote_creator):
+        vote_id = curve_dao.create_vote(
+            target, actions, description, etherscan_api_key, pinata_token
+        )
+
+    assert curve_dao.simulate(vote_id, target, etherscan_api_key)
+
+    boa.env.time_travel(
+        seconds=60 * 60 * 24 * 8
+    )  # sleep 7(+1) days for ramp to complete
+
+    assert pool.A() == 20000001
+    assert pool.gamma() == 20000000000000001
+    assert pool.mid_fee() == 700001
+    assert pool.out_fee() == 8000001
+    assert pool.fee_gamma() == 300000000000000001
+    assert pool.allowed_extra_profit() == 10000000001
+    assert pool.adjustment_step() == 5500000000001


### PR DESCRIPTION
Added support for `twocrypto` and `twocrypto-ng` parameter changes.

Current Setup: The function currently changes `A` and `gamma`, as well as all the fee parameters, simultaneously. imo ramping and fee parameter changes should be split into two separate functions, e.g. `ramp_twocrypto` and `update_twocrypto`, since it is rare for both to be changed at the same time. can or should i split them up (same applies to the current stableswap-ng setup)?

and bls double-check the ma_time input. sometimes its in seconds, sometimes not.